### PR TITLE
Dev qp register memory

### DIFF
--- a/comm_network/comm_network.h
+++ b/comm_network/comm_network.h
@@ -12,7 +12,6 @@ IBVerbsCommNet* InitCommNet(const EnvProto& env_proto, Channel<Msg>* action_chan
   Global<CtrlServer>::New();
   Global<CtrlClient>::New();
   Global<IBVerbsCommNet>::New(action_channel);
-  Global<IBVerbsCommNet>::Get()->RegisterFixNumMemory();
   return Global<IBVerbsCommNet>::Get();
 }
 
@@ -20,7 +19,6 @@ void DestroyCommNet() {
   Global<EnvDesc>::Delete();
   Global<CtrlServer>::Delete();
   Global<CtrlClient>::Delete();
-  Global<IBVerbsCommNet>::Get()->UnRegisterFixNumMemory();
   Global<IBVerbsCommNet>::Delete();
 }
 

--- a/comm_network/ibverbs.proto
+++ b/comm_network/ibverbs.proto
@@ -14,6 +14,6 @@ message IBVerbsConnectionInfo {
 }
 
 message IBVerbsTokensMsg {
-	map<string, IBVerbsMemDescProto> mem_desc = 2;
+	repeated IBVerbsMemDescProto peer_recv_mem_desc = 1;
 }
 

--- a/comm_network/ibverbs_comm_network.cpp
+++ b/comm_network/ibverbs_comm_network.cpp
@@ -4,30 +4,14 @@
 
 namespace comm_network {
 
-std::string GenTokensMsgKey(int64_t src_machine_id, int dst_machine_id) {
-  return "IBVerbsTokensMsg/" + std::to_string(src_machine_id) + "/"
-         + std::to_string(dst_machine_id);
-}
-
 std::string GenConnInfoKey(int64_t src_machine_id, int64_t dst_machine_id) {
   return "IBVerbsConnInfo/" + std::to_string(src_machine_id) + "/" + std::to_string(dst_machine_id);
-}
-
-std::string GenRegisterSendMemoryKey(int64_t src_machine_id, int64_t dst_machine_id, uint8_t idx) {
-  return "IBVerbsSendMemory/" + std::to_string(src_machine_id) + "/"
-         + std::to_string(dst_machine_id) + "/" + std::to_string(idx);
-}
-
-std::string GenRegisterRecvMemoryKey(int64_t src_machine_id, int64_t dst_machine_id, uint8_t idx) {
-  return "IBVerbsRecvMemory/" + std::to_string(src_machine_id) + "/"
-         + std::to_string(dst_machine_id) + "/" + std::to_string(idx);
 }
 
 IBVerbsCommNet::IBVerbsCommNet(Channel<Msg>* action_channel) : action_channel_(action_channel) {
   int64_t total_machine_num = Global<EnvDesc>::Get()->TotalMachineNum();
   this_machine_id_ =
       Global<EnvDesc>::Get()->GetMachineId(Global<CtrlServer>::Get()->this_machine_addr());
-  mem_desc_list_.resize(total_machine_num);
   for (int64_t i = 0; i < total_machine_num; ++i) {
     if (i == this_machine_id_) { continue; }
     peer_machine_id_.insert(i);
@@ -52,12 +36,9 @@ IBVerbsCommNet::IBVerbsCommNet(Channel<Msg>* action_channel) : action_channel_(a
   // poller : cq = 1 : 1, cq : qp : helper = 1 : peer_machines : peer_machines
   poller_ = new IBVerbsPoller(cq_);
   qp_vec_.assign(peer_machine_id_.size() + 1, nullptr);
-  helper_vec_.assign(peer_machine_id_.size() + 1, nullptr);
   for (int64_t peer_id : peer_machine_id()) {
-    IBVerbsHelper* cur_helper = new IBVerbsHelper;
-    IBVerbsQP* cur_qp = new IBVerbsQP(context_, pd_, cq_, cq_, cur_helper);
+    IBVerbsQP* cur_qp = new IBVerbsQP(context_, pd_, cq_, cq_, this_machine_id_, peer_id);
     qp_vec_.at(peer_id) = cur_qp;
-    helper_vec_.at(peer_id) = cur_helper;
     IBVerbsConnectionInfo conn_info;
     conn_info.set_lid(port_attr.lid);
     conn_info.set_qp_num(cur_qp->qp_num());
@@ -83,9 +64,6 @@ IBVerbsCommNet::~IBVerbsCommNet() {
   CHECK_EQ(read_queue_.size(), 0);
   for (IBVerbsQP* qp : qp_vec_) {
     if (qp) { delete qp; }
-  }
-  for (IBVerbsHelper* helper : helper_vec_) {
-    if (helper) { delete helper; }
   }
   poller_->Stop();
   delete poller_;
@@ -139,21 +117,6 @@ void IBVerbsCommNet::FreeReadId(uint32_t read_id) {
   CHECK_EQ(busy_read_ids_.erase(read_id), 1);
 }
 
-std::pair<IBVerbsMemDesc*, IBVerbsMemDescProto> IBVerbsCommNet::GetSendRecvMemPairForSender(
-    int64_t machine_id, uint8_t buffer_id) {
-  std::string send_key = GenRegisterSendMemoryKey(this_machine_id_, machine_id, buffer_id);
-  std::string recv_key = GenRegisterRecvMemoryKey(this_machine_id_, machine_id, buffer_id);
-  IBVerbsMemDesc* send_mem_desc = mem_desc_[send_key];
-  IBVerbsMemDescProto recv_mem_desc_proto = mem_desc_list_[machine_id][recv_key];
-  return std::make_pair(send_mem_desc, recv_mem_desc_proto);
-}
-
-IBVerbsMemDesc* IBVerbsCommNet::GetRecvMemDescForReceiver(int64_t machine_id, uint8_t buffer_id) {
-  std::string recv_key = GenRegisterRecvMemoryKey(machine_id, this_machine_id_, buffer_id);
-  IBVerbsMemDesc* recv_mem_desc = mem_desc_[recv_key];
-  return recv_mem_desc;
-}
-
 void IBVerbsCommNet::Normal2RegisterDone(int64_t dst_machine_id, IBVerbsMemDesc* send_mem_desc,
                                          IBVerbsMemDescProto recv_mem_desc_proto,
                                          uint32_t imm_data) {
@@ -178,53 +141,6 @@ void IBVerbsCommNet::Register2NormalDone(int64_t machine_id, uint8_t buffer_id, 
     }
     cb();
     FreeReadId(read_id);
-  }
-}
-
-void* IBVerbsCommNet::RegisterMemory(std::string key, void* ptr, size_t byte_size) {
-  IBVerbsMemDesc* mem_desc = new IBVerbsMemDesc(pd_, ptr, byte_size);
-  mem_desc_.emplace(key, mem_desc);
-  return mem_desc;
-}
-
-void IBVerbsCommNet::UnRegisterMemory(std::string key) {
-  IBVerbsMemDesc* mem_desc = mem_desc_[key];
-  delete mem_desc;
-  CHECK_EQ(mem_desc_.erase(key), 1);
-}
-
-void IBVerbsCommNet::RegisterFixNumMemory() {
-  for (int64_t peer_id : peer_machine_id()) {
-    IBVerbsTokensMsg this_tokens_msg;
-    for (int i = 0; i < num_of_register_buffer / 2; i++) {
-      std::string send_key = GenRegisterSendMemoryKey(this_machine_id_, peer_id, i);
-      std::string recv_key = GenRegisterRecvMemoryKey(peer_id, this_machine_id_, i);
-      void* send_buffer = malloc(buffer_size);
-      void* recv_buffer = malloc(buffer_size);
-      RegisterMemory(send_key, send_buffer, buffer_size);
-      RegisterMemory(recv_key, recv_buffer, buffer_size);
-      this_tokens_msg.mutable_mem_desc()->insert({send_key, mem_desc_[send_key]->ToProto()});
-      this_tokens_msg.mutable_mem_desc()->insert({recv_key, mem_desc_[recv_key]->ToProto()});
-    }
-    Global<CtrlClient>::Get()->PushKV(GenTokensMsgKey(this_machine_id_, peer_id), this_tokens_msg);
-  }
-  for (int64_t peer_id : peer_machine_id()) {
-    IBVerbsTokensMsg peer_tokens_msg;
-    Global<CtrlClient>::Get()->PullKV(GenTokensMsgKey(peer_id, this_machine_id_), &peer_tokens_msg);
-    for (const auto& pair : peer_tokens_msg.mem_desc()) {
-      mem_desc_list_.at(peer_id).emplace(pair.first, pair.second);
-    }
-  }
-  BARRIER();
-  for (int64_t peer_id : peer_machine_id()) {
-    Global<CtrlClient>::Get()->ClearKV(GenTokensMsgKey(this_machine_id_, peer_id));
-  }
-}
-
-void IBVerbsCommNet::UnRegisterFixNumMemory() {
-  while (!mem_desc_.empty()) {
-    auto iter = mem_desc_.begin();
-    UnRegisterMemory(iter->first);
   }
 }
 

--- a/comm_network/ibverbs_comm_network.h
+++ b/comm_network/ibverbs_comm_network.h
@@ -4,7 +4,6 @@
 #include "comm_network/ibverbs_qp.h"
 #include "comm_network/control/ctrl_client.h"
 #include "comm_network/control/ctrl_server.h"
-#include "comm_network/ibverbs_helper.h"
 #include "comm_network/ibverbs_poller.h"
 #include "comm_network/common/channel.h"
 
@@ -16,22 +15,18 @@ class IBVerbsCommNet final {
   ~IBVerbsCommNet();
 
   const std::unordered_set<int64_t>& peer_machine_id() { return peer_machine_id_; }
-  void RegisterFixNumMemory();
-  void UnRegisterFixNumMemory();
 
-  std::pair<IBVerbsMemDesc*, IBVerbsMemDescProto> GetSendRecvMemPairForSender(int64_t machine_id,
-                                                                              uint8_t buffer_id);
   WorkRecord GetWorkRecord(uint32_t read_id) {
     std::unique_lock<std::mutex> lock(read_queue_mtx_);
     CHECK(read_queue_.find(read_id) != read_queue_.end());
     return read_queue_.at(read_id);
   }
+  
   void SetWorkRecordOffset(uint32_t read_id, size_t offset) {
     std::unique_lock<std::mutex> lock(read_queue_mtx_);
     CHECK(read_queue_.find(read_id) != read_queue_.end());
     read_queue_.at(read_id).offset = offset;
   }
-  IBVerbsMemDesc* GetRecvMemDescForReceiver(int64_t machine_id, uint8_t buffer_id);
 
   void DoRead(int64_t src_machine_id, void* src_addr, void* dst_addr, size_t data_size,
               std::function<void()> callback);
@@ -43,20 +38,15 @@ class IBVerbsCommNet final {
                            bool last_piece);
 
  private:
-  void* RegisterMemory(std::string key, void* ptr, size_t byte_size);
-  void UnRegisterMemory(std::string key);
   uint32_t AllocateReadId();
   void FreeReadId(uint32_t read_id);
   std::unordered_set<int64_t> peer_machine_id_;
   std::vector<IBVerbsQP*> qp_vec_;
-  std::vector<IBVerbsHelper*> helper_vec_;
   ibv_context* context_;
   ibv_pd* pd_;
   ibv_cq* cq_;
   Channel<Msg>* action_channel_;
   int64_t this_machine_id_;
-  std::unordered_map<std::string, IBVerbsMemDesc*> mem_desc_;
-  std::vector<std::unordered_map<std::string, IBVerbsMemDescProto>> mem_desc_list_;
   std::unordered_set<uint32_t> busy_read_ids_;
   std::mutex busy_read_id_mtx_;
   std::mutex read_queue_mtx_;

--- a/comm_network/ibverbs_helper.cpp
+++ b/comm_network/ibverbs_helper.cpp
@@ -1,9 +1,9 @@
 #include "comm_network/ibverbs_helper.h"
 
 namespace comm_network {
-IBVerbsHelper::IBVerbsHelper() {
+IBVerbsHelper::IBVerbsHelper(const std::vector<std::pair<IBVerbsMemDesc*, IBVerbsMemDescProto>>& send_recv_pair) {
   read_helper_ = new IBVerbsReadHelper;
-  write_helper_ = new IBVerbsWriteHelper;
+  write_helper_ = new IBVerbsWriteHelper(send_recv_pair);
 }
 
 IBVerbsHelper::~IBVerbsHelper() {
@@ -12,8 +12,8 @@ IBVerbsHelper::~IBVerbsHelper() {
 }
 
 void IBVerbsHelper::AsyncWrite(const WorkRecord& record) { write_helper_->AsyncWrite(record); }
-void IBVerbsHelper::AsyncRead(uint32_t read_id, uint8_t buffer_id) {
-  read_helper_->AsyncRead(read_id, buffer_id);
+void IBVerbsHelper::SyncRead(uint32_t read_id, uint8_t buffer_id, IBVerbsMemDesc* recv_mem_desc) {
+  read_helper_->SyncRead(read_id, buffer_id, recv_mem_desc);
 }
 void IBVerbsHelper::FreeBuffer(uint8_t buffer_id) { write_helper_->FreeBuffer(buffer_id); }
 }  // namespace comm_network

--- a/comm_network/ibverbs_helper.h
+++ b/comm_network/ibverbs_helper.h
@@ -7,11 +7,11 @@ namespace comm_network {
 class IBVerbsHelper final {
  public:
   CN_DISALLOW_COPY_AND_MOVE(IBVerbsHelper);
-  IBVerbsHelper();
+  IBVerbsHelper(const std::vector<std::pair<IBVerbsMemDesc*, IBVerbsMemDescProto>>& send_recv_pair);
   ~IBVerbsHelper();
 
   void AsyncWrite(const WorkRecord& record);
-  void AsyncRead(uint32_t read_id, uint8_t buffer_id);
+  void SyncRead(uint32_t read_id, uint8_t buffer_id, IBVerbsMemDesc* recv_mem_desc);
   void FreeBuffer(uint8_t buffer_id);
 
  private:

--- a/comm_network/ibverbs_memory_desc.cpp
+++ b/comm_network/ibverbs_memory_desc.cpp
@@ -39,4 +39,9 @@ IBVerbsMemDescProto IBVerbsMemDesc::ToProto() {
   return proto;
 }
 
+void IBVerbsMemDesc::ToProto(IBVerbsMemDescProto* proto) {
+  for (const ibv_sge& sge : sge_vec_) { proto->add_mem_ptr(sge.addr); }
+  for (ibv_mr* mr : mr_vec_) { proto->add_mr_rkey(mr->rkey); }
+}
+
 }  // namespace comm_network

--- a/comm_network/ibverbs_memory_desc.h
+++ b/comm_network/ibverbs_memory_desc.h
@@ -15,6 +15,7 @@ class IBVerbsMemDesc final {
   const std::vector<ibv_sge>& sge_vec() const { return sge_vec_; }
 
   IBVerbsMemDescProto ToProto();
+  void ToProto(IBVerbsMemDescProto* proto);
 
  private:
   std::vector<ibv_sge> sge_vec_;

--- a/comm_network/ibverbs_qp.h
+++ b/comm_network/ibverbs_qp.h
@@ -35,7 +35,7 @@ class IBVerbsQP final {
  public:
   CN_DISALLOW_COPY_AND_MOVE(IBVerbsQP);
   IBVerbsQP() = delete;
-  IBVerbsQP(ibv_context*, ibv_pd*, ibv_cq* send_cq, ibv_cq* recv_cq, IBVerbsHelper* helper);
+  IBVerbsQP(ibv_context*, ibv_pd*, ibv_cq* send_cq, ibv_cq* recv_cq, int64_t this_machine_id, int64_t peer_machine_id);
   ~IBVerbsQP();
 
   uint32_t qp_num() const { return qp_->qp_num; }
@@ -65,5 +65,9 @@ class IBVerbsQP final {
   std::mutex send_msg_buf_mtx_;
   std::queue<MsgMR*> send_msg_buf_;
   IBVerbsHelper* helper_;
+  int64_t this_machine_id_;
+  int64_t peer_machine_id_;
+  std::vector<std::pair<IBVerbsMemDesc*, IBVerbsMemDesc*>> mem_desc_;
+  std::vector<std::pair<IBVerbsMemDesc*, IBVerbsMemDescProto>> send_recv_mem_desc_;
 };
 }  // namespace comm_network

--- a/comm_network/ibverbs_read_helper.cpp
+++ b/comm_network/ibverbs_read_helper.cpp
@@ -4,12 +4,10 @@
 
 namespace comm_network {
 
-void IBVerbsReadHelper::AsyncRead(uint32_t read_id, uint8_t buffer_id) {
+void IBVerbsReadHelper::SyncRead(uint32_t read_id, uint8_t buffer_id, IBVerbsMemDesc* recv_mem_desc) {
   // get work record using read_id
   WorkRecord cur_msg = Global<IBVerbsCommNet>::Get()->GetWorkRecord(read_id);
   int64_t src_machine_id = cur_msg.machine_id;
-  IBVerbsMemDesc* recv_mem_desc =
-      Global<IBVerbsCommNet>::Get()->GetRecvMemDescForReceiver(src_machine_id, buffer_id);
   // register memory to normal memory
   ibv_sge cur_sge = recv_mem_desc->sge_vec().at(0);
   size_t offset = cur_msg.offset;

--- a/comm_network/ibverbs_read_helper.h
+++ b/comm_network/ibverbs_read_helper.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "comm_network/common/utils.h"
+#include "comm_network/ibverbs_memory_desc.h"
 
 namespace comm_network {
 class IBVerbsReadHelper {
@@ -7,6 +8,6 @@ class IBVerbsReadHelper {
   CN_DISALLOW_COPY_AND_MOVE(IBVerbsReadHelper);
   IBVerbsReadHelper() = default;
   ~IBVerbsReadHelper() = default;
-  void AsyncRead(uint32_t read_id, uint8_t buffer_id);
+  void SyncRead(uint32_t read_id, uint8_t buffer_id, IBVerbsMemDesc* recv_mem_desc);
 };
 }  // namespace comm_network

--- a/comm_network/ibverbs_write_helper.cpp
+++ b/comm_network/ibverbs_write_helper.cpp
@@ -2,7 +2,7 @@
 #include "comm_network/ibverbs_comm_network.h"
 
 namespace comm_network {
-IBVerbsWriteHelper::IBVerbsWriteHelper() {
+IBVerbsWriteHelper::IBVerbsWriteHelper(const std::vector<std::pair<IBVerbsMemDesc*, IBVerbsMemDescProto>>& send_recv_pair) : send_recv_pair_(send_recv_pair) {
   cur_record_queue_ = new std::queue<WorkRecord>;
   pending_record_queue_ = new std::queue<WorkRecord>;
   for (int i = 0; i < num_of_register_buffer / 2; i++) { idle_buffer_queue_.push(i); }
@@ -61,8 +61,9 @@ void IBVerbsWriteHelper::FreeBuffer(uint8_t buffer_id) {
 
 bool IBVerbsWriteHelper::DoCurWrite() {
   // normal memory to register memory
-  auto mem_desc_pair = Global<IBVerbsCommNet>::Get()->GetSendRecvMemPairForSender(
-      cur_record_.machine_id, buffer_id_);
+  // auto mem_desc_pair = Global<IBVerbsCommNet>::Get()->GetSendRecvMemPairForSender(
+  //     cur_record_.machine_id, buffer_id_);
+  auto mem_desc_pair = send_recv_pair_[buffer_id_];
   IBVerbsMemDesc* send_mem_desc = mem_desc_pair.first;
   IBVerbsMemDescProto recv_mem_desc_proto = mem_desc_pair.second;
   ibv_sge cur_sge = send_mem_desc->sge_vec().at(0);

--- a/comm_network/ibverbs_write_helper.h
+++ b/comm_network/ibverbs_write_helper.h
@@ -2,13 +2,14 @@
 #include "comm_network/common/utils.h"
 #include "comm_network/ibverbs_poller.h"
 #include "comm_network/message.h"
+#include "comm_network/ibverbs_memory_desc.h"
 
 namespace comm_network {
 class IBVerbsWriteHelper final {
  public:
   CN_DISALLOW_COPY_AND_MOVE(IBVerbsWriteHelper);
   ~IBVerbsWriteHelper();
-  IBVerbsWriteHelper();
+  IBVerbsWriteHelper(const std::vector<std::pair<IBVerbsMemDesc*, IBVerbsMemDescProto>>& send_recv_pair);
 
   void AsyncWrite(const WorkRecord& record);
   void FreeBuffer(uint8_t buffer_id);
@@ -27,6 +28,7 @@ class IBVerbsWriteHelper final {
   std::mutex idle_buffer_queue_mtx_;
   WorkRecord cur_record_;
   bool (IBVerbsWriteHelper::*cur_write_handle_)();
+  std::vector<std::pair<IBVerbsMemDesc*, IBVerbsMemDescProto>> send_recv_pair_;
 };
 
 }  // namespace comm_network

--- a/test/test_comm_network.cpp
+++ b/test/test_comm_network.cpp
@@ -160,9 +160,8 @@ void TestCorrectness(int64_t this_machine_id, Channel<Msg>* action_channel,
   std::cout << "the latency is : " << duration_sec / 1000000.0
             << " s, the throughput is : " << (1.0 * total_bytes) / duration_sec << "MB/s.\n"
             << "Test for correctness. Done.\n\n";
-  for (int i = 0; i < test_num; i++) {
-    free(origin_ptr_list.at(i));
-  }
+  BARRIER();
+  for (int i = 0; i < test_num; i++) { free(origin_ptr_list.at(i)); }
 }
 
 int main(int argc, char* argv[]) {


### PR DESCRIPTION
主要是把注册内存的管理放到qp的抽象里管理，同时helper也应该由qp的抽象管理，不应该暴露在ibverbs_comm_net里。